### PR TITLE
Set up the docker image to publish to artifactory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,23 @@ branches:
   - master
 
 before_install:
-  - echo TODO Setup Artifactory credentials
+  - sudo su -c "echo -e \"deb https://${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}@meremortal.jfrog.io/meremortal/mortal-debian precise main\n\" >> /etc/apt/sources.list"
   - sudo apt-get update -qq
+  - docker login -u "${ARTIFACTORY_USER}" -p "${ARTIFACTORY_PASSWORD}" https://meremortal-mortal-docker.jfrog.io
 
 install:
   - echo TODO install debian package of CI Scripts.
+  - sudo apt-get install mere-mortal-ci
 
 script:
   - mvn -B clean install
-  - |-
-    docker build \
-    --build-arg version="$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)" \
-    --build-arg jar="$(mvn -q -Dexec.executable="echo" -Dexec.args='${jar.finalName}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec).jar" \
-    -t simple-service:latest .
+  - export SERVICE_VERSION="$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)"
+  - export JAR_NAME="$(mvn -q -Dexec.executable="echo" -Dexec.args='${jar.finalName}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec).jar"
+  - echo Built ${JAR_NAME} at version ${SERVICE_VERSION}
+  - docker build --build-arg version=${SERVICE_VERSION} --build-arg jar=${JAR_NAME} -t simple-service:latest .
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+      set -ev;
+      /opt/mere-mortals/swampup/increment-pom-version.sh;
+      /opt/mere-mortals/swampup/publish-docker-image.sh simple-service;
+    fi
+  - docker images

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Simple Example Service
 
+[![Build Status](https://travis-ci.org/SwampUpMereMortals/simple-service.svg?branch=master)](https://travis-ci.org/SwampUpMereMortals/simple-service)
+
 This is a basic Spring Boot service that is built, tested, and
 packaged as a docker image.  This code is not very interesting, but
 the surrounding CI/CD code (Travis Configurations) is.  Use this as a
@@ -15,14 +17,12 @@ multiple Docker images all being deployed to Kubernetes/GKE via Travis
 
 ## Build & Run as Docker
 
-1.
-
     docker build \
     --build-arg version=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec) \
     --build-arg jar=$(mvn -q -Dexec.executable="echo" -Dexec.args='${jar.finalName}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec).jar \
     -t simple-service:latest-dev .
 
-2. `docker run -p 8080:8080 simple-service:latest-dev`
+`docker run -p 8080:8080 simple-service:latest-dev`
 
-3. `curl http://192.168.99.100:8080/simple` (or whatever IP for docker
-   VM, etc).
+`curl http://192.168.99.100:8080/simple` (or whatever IP for docker
+VM, etc).


### PR DESCRIPTION
- Enable Artifactory via encrypted credentials.
- Set travis to publish every new successful build to artifactory, and
  bump the version in maven (increment the version).  This will produce
  a new docker image on every commit.